### PR TITLE
 Use as_strided for rolling window creation

### DIFF
--- a/analysis/data_loader.py
+++ b/analysis/data_loader.py
@@ -56,29 +56,23 @@ def load_images(ct_paths, lesion_paths):
     n_c = len(ct_paths[0])
     print(n_c, 'channels found.')
 
-    # TODO use np array instead
     ct_inputs = np.empty((len(ct_paths), n_x, n_y, n_z, n_c))
     lesion_outputs = np.empty((len(lesion_paths), n_x, n_y, n_z))
 
     for subject in range(len(ct_paths)):
         ct_channels = ct_paths[subject]
-        # ct_4d = np.zeros([n_x,n_y, n_z, n_c])
         for c in range(n_c):
             image = nib.load(ct_channels[c])
             image_data = image.get_data()
             if first_image_data.shape != image_data.shape:
                 raise ValueError('Image does not have correct dimensions.', ct_channels[c])
 
-            # ct_4d[:,:,:,c] = image_data
             ct_inputs[subject, :, :, :, c] = image_data
 
         lesion_image = nib.load(lesion_paths[subject])
         lesion_data = lesion_image.get_data()
 
         lesion_outputs[subject, :, :, :] = lesion_data
-
-        # ct_inputs.append(ct_4d)
-        # lesion_outputs.append(lesion_data)
 
     return (ct_inputs, lesion_outputs)
 

--- a/analysis/data_loader.py
+++ b/analysis/data_loader.py
@@ -49,9 +49,6 @@ def load_images(ct_paths, lesion_paths):
     if len(ct_paths) != len(lesion_paths):
         raise ValueError('Number of CT and number of lesions maps should be the same.', len(ct_paths), len(lesion_paths))
 
-    ct_inputs = []
-    lesion_outputs = []
-
     # get dimensions by extracting first image
     first_image = nib.load(ct_paths[0][0])
     first_image_data = first_image.get_data()
@@ -59,22 +56,29 @@ def load_images(ct_paths, lesion_paths):
     n_c = len(ct_paths[0])
     print(n_c, 'channels found.')
 
+    # TODO use np array instead
+    ct_inputs = np.empty((len(ct_paths), n_x, n_y, n_z, n_c))
+    lesion_outputs = np.empty((len(lesion_paths), n_x, n_y, n_z))
+
     for subject in range(len(ct_paths)):
         ct_channels = ct_paths[subject]
-        ct_4d = np.zeros([n_x,n_y, n_z, n_c])
+        # ct_4d = np.zeros([n_x,n_y, n_z, n_c])
         for c in range(n_c):
             image = nib.load(ct_channels[c])
             image_data = image.get_data()
             if first_image_data.shape != image_data.shape:
                 raise ValueError('Image does not have correct dimensions.', ct_channels[c])
 
-            ct_4d[:,:,:,c] = image_data
+            # ct_4d[:,:,:,c] = image_data
+            ct_inputs[subject, :, :, :, c] = image_data
 
         lesion_image = nib.load(lesion_paths[subject])
         lesion_data = lesion_image.get_data()
 
-        ct_inputs.append(ct_4d)
-        lesion_outputs.append(lesion_data)
+        lesion_outputs[subject, :, :, :] = lesion_data
+
+        # ct_inputs.append(ct_4d)
+        # lesion_outputs.append(lesion_data)
 
     return (ct_inputs, lesion_outputs)
 

--- a/analysis/rolling_window.py
+++ b/analysis/rolling_window.py
@@ -1,0 +1,169 @@
+import numpy as np
+
+def rolling_window(array, window=(0,), asteps=None, wsteps=None, axes=None, toend=True):
+    """Create a view of `array` which for every point gives the n-dimensional
+    neighbourhood of size window. New dimensions are added at the end of
+    `array` or after the corresponding original dimension.
+
+    Parameters
+    ----------
+    array : array_like
+        Array to which the rolling window is applied.
+    window : int or tuple
+        Either a single integer to create a window of only the last axis or a
+        tuple to create it for the last len(window) axes. 0 can be used as a
+        to ignore a dimension in the window.
+    asteps : tuple
+        Aligned at the last axis, new steps for the original array, ie. for
+        creation of non-overlapping windows. (Equivalent to slicing result)
+    wsteps : int or tuple (same size as window)
+        steps for the added window dimensions. These can be 0 to repeat values
+        along the axis.
+    axes: int or tuple
+        If given, must have the same size as window. In this case window is
+        interpreted as the size in the dimension given by axes. IE. a window
+        of (2, 1) is equivalent to window=2 and axis=-2.
+    toend : bool
+        If False, the new dimensions are right after the corresponding original
+        dimension, instead of at the end of the array. Adding the new axes at the
+        end makes it easier to get the neighborhood, however toend=False will give
+        a more intuitive result if you view the whole array.
+
+    Returns
+    -------
+    A view on `array` which is smaller to fit the windows and has windows added
+    dimensions (0s not counting), ie. every point of `array` is an array of size
+    window.
+
+    Examples
+    --------
+    >>> a = np.arange(9).reshape(3,3)
+    >>> rolling_window(a, (2,2))
+    array([[[[0, 1],
+             [3, 4]],
+
+            [[1, 2],
+             [4, 5]]],
+
+
+           [[[3, 4],
+             [6, 7]],
+
+            [[4, 5],
+             [7, 8]]]])
+
+    Or to create non-overlapping windows, but only along the first dimension:
+    >>> rolling_window(a, (2,0), asteps=(2,1))
+    array([[[0, 3],
+            [1, 4],
+            [2, 5]]])
+
+    Note that the 0 is discared, so that the output dimension is 3:
+    >>> rolling_window(a, (2,0), asteps=(2,1)).shape
+    (1, 3, 2)
+
+    This is useful for example to calculate the maximum in all (overlapping)
+    2x2 submatrixes:
+    >>> rolling_window(a, (2,2)).max((2,3))
+    array([[4, 5],
+           [7, 8]])
+
+    Or delay embedding (3D embedding with delay 2):
+    >>> x = np.arange(10)
+    >>> rolling_window(x, 3, wsteps=2)
+    array([[0, 2, 4],
+           [1, 3, 5],
+           [2, 4, 6],
+           [3, 5, 7],
+           [4, 6, 8],
+           [5, 7, 9]])
+    """
+    array = np.asarray(array)
+    orig_shape = np.asarray(array.shape)
+    window = np.atleast_1d(window).astype(int) # maybe crude to cast to int...
+
+    if axes is not None:
+        axes = np.atleast_1d(axes)
+        w = np.zeros(array.ndim, dtype=int)
+        for axis, size in zip(axes, window):
+            w[axis] = size
+        window = w
+
+    # Check if window is legal:
+    if window.ndim > 1:
+        raise ValueError("`window` must be one-dimensional.")
+    if np.any(window < 0):
+        raise ValueError("All elements of `window` must be larger then 1.")
+    if len(array.shape) < len(window):
+        raise ValueError("`window` length must be less or equal `array` dimension.")
+
+    _asteps = np.ones_like(orig_shape)
+    if asteps is not None:
+        asteps = np.atleast_1d(asteps)
+        if asteps.ndim != 1:
+            raise ValueError("`asteps` must be either a scalar or one dimensional.")
+        if len(asteps) > array.ndim:
+            raise ValueError("`asteps` cannot be longer then the `array` dimension.")
+        # does not enforce alignment, so that steps can be same as window too.
+        _asteps[-len(asteps):] = asteps
+
+        if np.any(asteps < 1):
+             raise ValueError("All elements of `asteps` must be larger then 1.")
+    asteps = _asteps
+
+    _wsteps = np.ones_like(window)
+    if wsteps is not None:
+        wsteps = np.atleast_1d(wsteps)
+        if wsteps.shape != window.shape:
+            raise ValueError("`wsteps` must have the same shape as `window`.")
+        if np.any(wsteps < 0):
+             raise ValueError("All elements of `wsteps` must be larger then 0.")
+
+        _wsteps[:] = wsteps
+        _wsteps[window == 0] = 1 # make sure that steps are 1 for non-existing dims.
+    wsteps = _wsteps
+
+    # Check that the window would not be larger then the original:
+    if np.any(orig_shape[-len(window):] < window * wsteps):
+        raise ValueError("`window` * `wsteps` larger then `array` in at least one dimension.")
+
+    new_shape = orig_shape # just renaming...
+
+    # For calculating the new shape 0s must act like 1s:
+    _window = window.copy()
+    _window[_window==0] = 1
+
+    new_shape[-len(window):] += wsteps - _window * wsteps
+    new_shape = (new_shape + asteps - 1) // asteps
+    # make sure the new_shape is at least 1 in any "old" dimension (ie. steps
+    # is (too) large, but we do not care.
+    new_shape[new_shape < 1] = 1
+    shape = new_shape
+
+    strides = np.asarray(array.strides)
+    strides *= asteps
+    new_strides = array.strides[-len(window):] * wsteps
+
+    # The full new shape and strides:
+    if toend:
+        new_shape = np.concatenate((shape, window))
+        new_strides = np.concatenate((strides, new_strides))
+    else:
+        _ = np.zeros_like(shape)
+        _[-len(window):] = window
+        _window = _.copy()
+        _[-len(window):] = new_strides
+        _new_strides = _
+
+        new_shape = np.zeros(len(shape)*2, dtype=int)
+        new_strides = np.zeros(len(shape)*2, dtype=int)
+
+        new_shape[::2] = shape
+        new_strides[::2] = strides
+        new_shape[1::2] = _window
+        new_strides[1::2] = _new_strides
+
+    new_strides = new_strides[new_shape != 0]
+    new_shape = new_shape[new_shape != 0]
+
+    return np.lib.stride_tricks.as_strided(array, shape=new_shape, strides=new_strides)

--- a/analysis/rolling_window.py
+++ b/analysis/rolling_window.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+# As created by https://gist.github.com/seberg/3866040
+
 def rolling_window(array, window=(0,), asteps=None, wsteps=None, axes=None, toend=True):
     """Create a view of `array` which for every point gives the n-dimensional
     neighbourhood of size window. New dimensions are added at the end of

--- a/analysis/voxelWise/model_utils.py
+++ b/analysis/voxelWise/model_utils.py
@@ -46,7 +46,15 @@ def create(model_dir, model_name, input_data_list, output_data_list, receptive_f
 
 def evaluate_model(model_dir, model_name, input_data_list, output_data_list, receptive_field_dimensions):
     model_path = os.path.join(model_dir, model_name)
+    import psutil, timeit
+    print(psutil.virtual_memory())
+    print(psutil.swap_memory())
+    start = timeit.timeit()
     rf_inputs, rf_outputs = rf.reshape_to_receptive_field(input_data_list, output_data_list, receptive_field_dimensions)
+    end = timeit.timeit()
+    print('Reshaped to receptive fields in: ', end - start)
+    print(psutil.virtual_memory())
+    print(psutil.swap_memory())
 
     model = XGBClassifier(verbose_eval=True, n_jobs = -1, tree_method = 'hist')
 

--- a/analysis/voxelWise/model_utils.py
+++ b/analysis/voxelWise/model_utils.py
@@ -36,10 +36,10 @@ def create(model_dir, model_name, input_data_list, output_data_list, receptive_f
 
     return model
 
-def evaluate_model(model_dir, model_name, input_data_list, output_data_list, receptive_field_dimensions):
+def evaluate_model(model_dir, model_name, input_data_array, output_data_array, receptive_field_dimensions):
     model_path = os.path.join(model_dir, model_name)
     start = timeit.default_timer()
-    rf_inputs, rf_outputs = rf.reshape_to_receptive_field(input_data_list, output_data_list, receptive_field_dimensions)
+    rf_inputs, rf_outputs = rf.reshape_to_receptive_field(input_data_array, output_data_array, receptive_field_dimensions)
     end = timeit.default_timer()
     print('Reshaped to receptive fields in: ', end - start)
 

--- a/analysis/voxelWise/model_utils.py
+++ b/analysis/voxelWise/model_utils.py
@@ -47,10 +47,10 @@ def evaluate_model(model_dir, model_name, input_data_array, output_data_array, r
 
     # Reduce amount of data initially processed
     # # TODO: train test split might create copy of data and might thus elevate RAM usage
-    remaining_fraction = 0.1
-    print('Discarding ' + str((1 - remaining_fraction)* 100) + '% of data for faster training')
-    X_retained, X_rest, y_retained, y_rest = train_test_split(rf_inputs, rf_outputs, test_size = 0.7, random_state = 42)
-    X, y = X_retained, y_retained
+    # remaining_fraction = 0.1
+    # print('Discarding ' + str((1 - remaining_fraction)* 100) + '% of data for faster training')
+    # X_retained, X_rest, y_retained, y_rest = train_test_split(rf_inputs, rf_outputs, test_size = 0.7, random_state = 42)
+    # X, y = X_retained, y_retained
 
     # kf = RepeatedKFold(n_splits = 5, n_repeats = 100, random_state = 42)
     # scoring = ('accuracy', 'roc_auc', 'f1')
@@ -110,7 +110,8 @@ def repeated_kfold_cv(model, X, y, n_repeats = 1, n_folds = 5):
         kf = KFold(n_splits = n_folds, shuffle = True, random_state = j)
         for train, test in kf.split(X, y):
             print('Evaluating split : ' + str(f))
-            X_train, y_train = balance(X[train], y[train])
+            # X_train, y_train = balance(X[train], y[train])
+            X_train, y_train = X[train], y[train]
 
             probas_ = model.fit(X_train, y_train).predict_proba(X[test])
             # Compute ROC curve, area under the curve, f1, and accuracy

--- a/analysis/voxelWise/model_utils.py
+++ b/analysis/voxelWise/model_utils.py
@@ -46,6 +46,7 @@ def evaluate_model(model_dir, model_name, input_data_array, output_data_array, r
     model = XGBClassifier(verbose_eval=True, n_jobs = -1, tree_method = 'hist')
 
     # Reduce amount of data initially processed
+    # # TODO: train test split might create copy of data and might thus elevate RAM usage
     remaining_fraction = 0.1
     print('Discarding ' + str((1 - remaining_fraction)* 100) + '% of data for faster training')
     X_retained, X_rest, y_retained, y_rest = train_test_split(rf_inputs, rf_outputs, test_size = 0.7, random_state = 42)
@@ -105,6 +106,7 @@ def repeated_kfold_cv(model, X, y, n_repeats = 1, n_folds = 5):
         print('Crossvalidation: Running ' + str(iteration) + ' of a total of ' + str(n_repeats))
 
         f = 0
+        # TODO: implement patient wise
         kf = KFold(n_splits = n_folds, shuffle = True, random_state = j)
         for train, test in kf.split(X, y):
             print('Evaluating split : ' + str(f))

--- a/analysis/voxelWise/prediction.py
+++ b/analysis/voxelWise/prediction.py
@@ -1,7 +1,7 @@
 import sys
 sys.path.insert(0, '../')
 
-import os
+import os, timeit
 import nibabel as nib
 import numpy as np
 from sklearn.externals import joblib
@@ -9,19 +9,21 @@ import receptiveField as rf
 import visual
 import data_loader
 
-main_dir = '/Users/julian/master/server_output/test1'
-data_dir = os.path.join(main_dir, 'LOO')
-model_dir = os.path.join(main_dir, 'models')
-model_path = os.path.join(model_dir, 'xgb_all_oversampled1.pkl')
+main_dir = '/Users/julian/master/data/'
+data_dir = os.path.join(main_dir, 'analysis_test2')
+model_dir = os.path.join(data_dir, 'temp_stride_test')
+model_name = 'old_rf0'
+model_extension = '.pkl'
+model_path = os.path.join(model_dir, model_name + model_extension)
 
 input_dir = os.path.join(data_dir, '')
 
-input_image_path = os.path.join(input_dir, '898729/Ct2_Cerebrale/wcoreg_RAPID_MTT_898729.nii')
+input_image_path = os.path.join(input_dir, 'Barlovic_Radojka_19480907/Ct2_Cerebral_20160103/wcoreg_RAPID_MTT_[s]_Barlovic_Radojka_19480907.nii')
 input_img = nib.load(input_image_path)
 # input_data = input_img.get_data()
 
-ct_sequences = ['wcoreg_RAPID_Tmax', 'wcoreg_RAPID_MTT', 'wcoreg_RAPID_rCBV', 'wcoreg_RAPID_rCBF']
-# ct_sequences = ['wcoreg_RAPID_TMax_[s]', 'wcoreg_RAPID_MTT_[s]', 'wcoreg_RAPID_CBV', 'wcoreg_RAPID_CBF']
+# ct_sequences = ['wcoreg_RAPID_Tmax', 'wcoreg_RAPID_MTT', 'wcoreg_RAPID_rCBV', 'wcoreg_RAPID_rCBF']
+ct_sequences = ['wcoreg_RAPID_TMax_[s]', 'wcoreg_RAPID_MTT_[s]', 'wcoreg_RAPID_CBV', 'wcoreg_RAPID_CBF']
 # ct_sequences = ['wcoreg_RAPID_TMax_[s]']
 mri_sequences = ['wcoreg_VOI_lesion']
 
@@ -29,16 +31,25 @@ IN, OUT = data_loader.load(input_dir, ct_sequences, mri_sequences)
 
 input_data = IN[0]
 
-rf_dim = [1, 1, 1]
+homogenous_rf = 0
+rf_dim = [homogenous_rf, homogenous_rf, homogenous_rf]
 
+print('Predict output image with model: ', model_name)
 model = joblib.load(model_path)
+
+start = timeit.default_timer()
 predicted = rf.predict(input_data, model, rf_dim)
+end = timeit.default_timer()
+print('Prediction time: ', end - start)
+
+
 print('Predicted shape', predicted.shape)
 print('Predicted lesion size', np.sum(predicted))
 
 coordinate_space = input_img.affine
+image_extension = '.nii'
 predicted_img = nib.Nifti1Image(predicted, affine=coordinate_space)
-nib.save(predicted_img, os.path.join(data_dir,'xgb_all_oversampled1_loo.nii'))
+nib.save(predicted_img, os.path.join(model_dir, model_name + '_oldPred_2' + image_extension))
 
 
 visual.display(predicted)

--- a/analysis/voxelWise/prediction.py
+++ b/analysis/voxelWise/prediction.py
@@ -12,13 +12,13 @@ import data_loader
 main_dir = '/Users/julian/master/data/'
 data_dir = os.path.join(main_dir, 'analysis_test2')
 model_dir = os.path.join(data_dir, 'temp_stride_test')
-model_name = 'old_rf0'
+model_name = 'gl_shorter_new_test_rf0'
 model_extension = '.pkl'
 model_path = os.path.join(model_dir, model_name + model_extension)
 
 input_dir = os.path.join(data_dir, '')
 
-input_image_path = os.path.join(input_dir, 'Barlovic_Radojka_19480907/Ct2_Cerebral_20160103/wcoreg_RAPID_MTT_[s]_Barlovic_Radojka_19480907.nii')
+input_image_path = os.path.join(input_dir, 'patient/Ct2_Cerebral_20160103/wcoreg_RAPID_MTT_[s]_patient_19480907.nii')
 input_img = nib.load(input_image_path)
 # input_data = input_img.get_data()
 
@@ -49,7 +49,7 @@ print('Predicted lesion size', np.sum(predicted))
 coordinate_space = input_img.affine
 image_extension = '.nii'
 predicted_img = nib.Nifti1Image(predicted, affine=coordinate_space)
-nib.save(predicted_img, os.path.join(model_dir, model_name + '_oldPred_2' + image_extension))
+nib.save(predicted_img, os.path.join(model_dir, model_name + '' + image_extension))
 
 
 visual.display(predicted)

--- a/analysis/voxelWise/receptiveField.py
+++ b/analysis/voxelWise/receptiveField.py
@@ -36,11 +36,12 @@ def shorter_new_reshape_to_receptive_field(input_data_list, output_data_list, re
     padding = max([rf_x, rf_y, rf_z])
     padded_data = [pad(x, padding) for x in input_data_list]
 
-    input_fields = np.array([rolling_window(x, (window_d_x, window_d_y, window_d_z, 0)) for x in padded_data])
+    # TODO stack subjects first and then use rolling_window with dimension 1 as 0, (0, window_d_x, window_d_y, window_d_z, 0)
+    input_fields = np.stack([rolling_window(x, (window_d_x, window_d_y, window_d_z, 0)) for x in padded_data])
 
     inputs = input_fields.reshape((n_subjects * n_voxels_per_subject, receptive_field_size))
 
-    outputs = np.array(output_data_list).reshape(n_subjects * n_voxels_per_subject)
+    outputs = np.stack(output_data_list).reshape(n_subjects * n_voxels_per_subject)
 
     print('Entire dataset. Input shape: ', inputs.shape,
           ' and output shape: ', outputs.shape)
@@ -263,7 +264,7 @@ def predict(input_data, model, receptive_field_dimensions):
         # output[x, y, z] = (1 - model.predict_proba(linear_input)[0][1])
 
     return output
-
+# TODO use np funciton
 def pad(image_with_channels, padding):
     """
     Pad input image with 0 (neutral) border to be able to get an receptive field at corner voxels

--- a/analysis/voxelWise/receptiveField.py
+++ b/analysis/voxelWise/receptiveField.py
@@ -7,7 +7,9 @@ import numpy as np
 import itertools
 
 def reshape_to_receptive_field(input_data_list, output_data_list, receptive_field_dimensions) :
-    temp = short_new_reshape_to_receptive_field(input_data_list, output_data_list, receptive_field_dimensions)
+    temp = shorter_new_reshape_to_receptive_field(input_data_list, output_data_list, receptive_field_dimensions)
+
+    # temp = short_new_reshape_to_receptive_field(input_data_list, output_data_list, receptive_field_dimensions)
     # a_temp, b_temp = short_new_reshape_to_receptive_field(input_data_list, output_data_list, receptive_field_dimensions)
     # a_temp2, b_temp2 = new_reshape_to_receptive_field(input_data_list, output_data_list, receptive_field_dimensions)
     #
@@ -16,6 +18,34 @@ def reshape_to_receptive_field(input_data_list, output_data_list, receptive_fiel
     # temp = old_reshape_to_receptive_field(input_data_list, output_data_list, receptive_field_dimensions)
 
     return temp
+
+def shorter_new_reshape_to_receptive_field(input_data_list, output_data_list, receptive_field_dimensions) :
+    # Dimensions of the receptive field defined as distance to center point in every direction
+    rf_x, rf_y, rf_z = receptive_field_dimensions
+    window_d_x, window_d_y, window_d_z  = 2 * np.array(receptive_field_dimensions) + 1
+    print('Receptive field window dimensions are: ', window_d_x, window_d_y, window_d_z )
+
+    n_subjects = len(input_data_list)
+    n_receptive_fields = input_data_list[0][:, :, :, 0].size * n_subjects  # ie voxels per image times number of images
+    receptive_field_size = window_d_x * window_d_y * window_d_z * input_data_list[0][0,0,0,:].size
+    n_x, n_y, n_z, n_c = input_data_list[0].shape
+    n_voxels_per_subject = n_x * n_y * n_z
+
+
+    # pad all images to allow for an receptive field even at the borders
+    padding = max([rf_x, rf_y, rf_z])
+    padded_data = [pad(x, padding) for x in input_data_list]
+
+    input_fields = np.array([rolling_window(x, (window_d_x, window_d_y, window_d_z, 0)) for x in padded_data])
+
+    inputs = input_fields.reshape((n_subjects * n_voxels_per_subject, receptive_field_size))
+
+    outputs = np.array(output_data_list).reshape(n_subjects * n_voxels_per_subject)
+
+    print('Entire dataset. Input shape: ', inputs.shape,
+          ' and output shape: ', outputs.shape)
+
+    return inputs, outputs
 
 def short_new_reshape_to_receptive_field(input_data_list, output_data_list, receptive_field_dimensions) :
     # Dimensions of the receptive field defined as distance to center point in every direction

--- a/analysis/voxelWise/receptiveField.py
+++ b/analysis/voxelWise/receptiveField.py
@@ -34,12 +34,8 @@ def shorter_new_reshape_to_receptive_field(input_data_array, output_data_array, 
     # pad all images to allow for an receptive field even at the borders
     padding = max([rf_x, rf_y, rf_z])
     padded_data = np.pad(input_data_array, ((0,0), (padding, padding), (padding, padding), (padding, padding), (0,0)), mode='constant', constant_values=0)
-    # padded_data = [pad(x, padding) for x in input_data_array]
-
-    # TODO stack subjects first and then use rolling_window with dimension 1 as 0, (0, window_d_x, window_d_y, window_d_z, 0)
 
     input_fields = rolling_window(padded_data, (0, window_d_x, window_d_y, window_d_z, 0))
-    # input_fields = np.stack([rolling_window(x, (window_d_x, window_d_y, window_d_z, 0)) for x in padded_data])
 
     inputs = input_fields.reshape((n_subjects * n_voxels_per_subject, receptive_field_size))
 

--- a/analysis/voxelWise/receptiveField.py
+++ b/analysis/voxelWise/receptiveField.py
@@ -16,9 +16,11 @@ def reshape_to_receptive_field(input_data_list, output_data_list, receptive_fiel
     #
     window_d_x, window_d_y, window_d_z  = 2 * np.array(receptive_field_dimensions) + 1
     print('Receptive field window dimensions are: ', window_d_x, window_d_y, window_d_z )
-    # Initialize the inputs array as long as there are voxels in an image, and on the second dimensions as many voxels as there are in a receptive field
-    inputs = np.empty((input_data_list[0][:,:,:,0].size, window_d_x * window_d_y * window_d_z * input_data_list[0][0,0,0,:].size))
-    output = np.empty(input_data_list[0][:,:,:,0].size)
+    # Initialize the inputs array as long as there will be receptive fields, and on the second dimensions as many voxels as there are in a receptive field
+    n_receptive_fields = input_data_list[0][:, :, :, 0].size * len(input_data_list) # ie voxels per image times number of images
+    receptive_field_size = window_d_x * window_d_y * window_d_z * input_data_list[0][0,0,0,:].size
+    inputs = np.empty((n_receptive_fields, receptive_field_size))
+    output = np.empty(n_receptive_fields)
 
     # Iterate through all images
     for i in range(0, len(input_data_list)):

--- a/analysis/voxelWise/receptiveField.py
+++ b/analysis/voxelWise/receptiveField.py
@@ -8,10 +8,10 @@ import itertools
 
 def reshape_to_receptive_field(input_data_list, output_data_list, receptive_field_dimensions) :
     temp = short_new_reshape_to_receptive_field(input_data_list, output_data_list, receptive_field_dimensions)
+    # a_temp, b_temp = short_new_reshape_to_receptive_field(input_data_list, output_data_list, receptive_field_dimensions)
     # a_temp2, b_temp2 = new_reshape_to_receptive_field(input_data_list, output_data_list, receptive_field_dimensions)
-
+    #
     # print('comparing inpout, output', np.array_equal(a_temp, a_temp2), np.array_equal(b_temp, b_temp2))
-
 
     # temp = old_reshape_to_receptive_field(input_data_list, output_data_list, receptive_field_dimensions)
 
@@ -53,7 +53,7 @@ def short_new_reshape_to_receptive_field(input_data_list, output_data_list, rece
         # (do not use the 4th dimension for patches, as this is the perfusion parameter channel)
         input_fields = rolling_window(padded_input_data, (window_d_x, window_d_y, window_d_z, 0))
         # Reshape to linear input
-        linear_input_fields = input_fields.reshape((n_voxels_per_subject, n_c))
+        linear_input_fields = input_fields.reshape((n_voxels_per_subject, receptive_field_size))
         inputs[index : index + n_voxels_per_subject] = linear_input_fields
 
         # Reshape to linear output
@@ -117,13 +117,6 @@ def new_reshape_to_receptive_field(input_data_list, output_data_list, receptive_
             output[index] = output_voxel
             index += 1
             # output.append(output_voxel)
-
-        lin_reshape = input_fields.reshape((n_x * n_y * n_z, n_c))
-        lin_reshape_out = output_data.reshape(n_x * n_y * n_z)
-        print('ooooooooooooo', lin_reshape.shape, inputs.shape, np.array_equal(lin_reshape, inputs))
-        print('iiiiiiiii', lin_reshape_out.shape, lin_reshape_out.shape, np.array_equal(lin_reshape_out, output))
-
-
 
 
     # inputs = np.squeeze(inputs)

--- a/analysis/voxelWise/receptiveField.py
+++ b/analysis/voxelWise/receptiveField.py
@@ -16,7 +16,8 @@ def reshape_to_receptive_field(input_data_list, output_data_list, receptive_fiel
     #
     window_d_x, window_d_y, window_d_z  = 2 * np.array(receptive_field_dimensions) + 1
     print('Receptive field window dimensions are: ', window_d_x, window_d_y, window_d_z )
-    inputs = np.empty((input_data_list[0][:,:,:,0].size, window_d_x * window_d_y * window_d_z, input_data_list[0][0,0,0,:].size))
+    # Initialize the inputs array as long as there are voxels in an image, and on the second dimensions as many voxels as there are in a receptive field
+    inputs = np.empty((input_data_list[0][:,:,:,0].size, window_d_x * window_d_y * window_d_z * input_data_list[0][0,0,0,:].size))
     output = np.empty(input_data_list[0][:,:,:,0].size)
 
     # Iterate through all images
@@ -43,7 +44,7 @@ def reshape_to_receptive_field(input_data_list, output_data_list, receptive_fiel
 
             # Reshape to linear input
             linear_input_field = np.reshape(input_fields[x, y, z], input_fields[x, y, z].size)
-            inputs[index, :, :] = linear_input_field
+            inputs[index, :] = linear_input_field
             # inputs.append(linear_input_field)
 
             output_voxel = np.array([output_data[x, y, z]])

--- a/analysis/voxelWise/receptiveField.py
+++ b/analysis/voxelWise/receptiveField.py
@@ -2,24 +2,9 @@ import sys
 sys.path.insert(0, '../')
 
 from rolling_window import rolling_window
-
 import numpy as np
-import itertools
 
 def reshape_to_receptive_field(input_data_array, output_data_array, receptive_field_dimensions) :
-    temp = shorter_new_reshape_to_receptive_field(input_data_array, output_data_array, receptive_field_dimensions)
-
-    # temp = short_new_reshape_to_receptive_field(input_data_array, output_data_array, receptive_field_dimensions)
-    # a_temp, b_temp = short_new_reshape_to_receptive_field(input_data_array, output_data_array, receptive_field_dimensions)
-    # a_temp2, b_temp2 = new_reshape_to_receptive_field(input_data_array, output_data_array, receptive_field_dimensions)
-    #
-    # print('comparing inpout, output', np.array_equal(a_temp, a_temp2), np.array_equal(b_temp, b_temp2))
-
-    # temp = old_reshape_to_receptive_field(input_data_array, output_data_array, receptive_field_dimensions)
-
-    return temp
-
-def shorter_new_reshape_to_receptive_field(input_data_array, output_data_array, receptive_field_dimensions) :
     # Dimensions of the receptive field defined as distance to center point in every direction
     rf_x, rf_y, rf_z = receptive_field_dimensions
     window_d_x, window_d_y, window_d_z  = 2 * np.array(receptive_field_dimensions) + 1
@@ -46,240 +31,28 @@ def shorter_new_reshape_to_receptive_field(input_data_array, output_data_array, 
 
     return inputs, outputs
 
-def short_new_reshape_to_receptive_field(input_data_array, output_data_array, receptive_field_dimensions) :
-    # Dimensions of the receptive field defined as distance to center point in every direction
-    rf_x, rf_y, rf_z = receptive_field_dimensions
-    window_d_x, window_d_y, window_d_z  = 2 * np.array(receptive_field_dimensions) + 1
-    print('Receptive field window dimensions are: ', window_d_x, window_d_y, window_d_z )
-
-    # Declare final array going into model
-    # Initialize the inputs array as long as there will be receptive fields, and on the second dimensions as many voxels as there are in a receptive field
-    n_receptive_fields = input_data_array[0][:, :, :, 0].size * len(input_data_array) # ie voxels per image times number of images
-    receptive_field_size = window_d_x * window_d_y * window_d_z * input_data_array[0][0,0,0,:].size
-    inputs = np.empty((n_receptive_fields, receptive_field_size))
-    outputs = np.empty(n_receptive_fields)
-
-    index = 0
-
-
-    # Iterate through all images
-    for i in range(0, len(input_data_array)):
-
-        input_data = input_data_array[i]
-        output_data = output_data_array[i]
-
-        if (input_data[:,:,:,0].shape != output_data.shape):
-            raise ValueError('Input and output do not have the same shape.', input_data[:,:,:,0].shape, output_data.shape)
-
-        n_x, n_y, n_z, n_c = input_data.shape
-        n_voxels_per_subject = n_x * n_y * n_z
-
-        # pad the image to allow for an receptive field even at the borders
-        padding = max([rf_x, rf_y, rf_z])
-        padded_input_data = pad(input_data, padding)
-
-        # Create patches centered on all the voxels in the image
-        # (do not use the 4th dimension for patches, as this is the perfusion parameter channel)
-        input_fields = rolling_window(padded_input_data, (window_d_x, window_d_y, window_d_z, 0))
-        # Reshape to linear input
-        linear_input_fields = input_fields.reshape((n_voxels_per_subject, receptive_field_size))
-        inputs[index : index + n_voxels_per_subject] = linear_input_fields
-
-        # Reshape to linear output
-        linear_output = output_data.reshape(n_voxels_per_subject)
-        outputs[index : index + n_voxels_per_subject] = linear_output
-
-        index += n_voxels_per_subject
-    # End for (loop through subjects)
-
-    print('Entire dataset. Input shape: ', inputs.shape,
-          ' and output shape: ', outputs.shape)
-
-    return inputs, outputs
-
-
-def new_reshape_to_receptive_field(input_data_array, output_data_array, receptive_field_dimensions) :
-    # Dimensions of the receptive field defined as distance to center point in every direction
-    rf_x, rf_y, rf_z = receptive_field_dimensions
-    window_d_x, window_d_y, window_d_z  = 2 * np.array(receptive_field_dimensions) + 1
-    print('Receptive field window dimensions are: ', window_d_x, window_d_y, window_d_z )
-
-    # Declare final array going into model
-    # Initialize the inputs array as long as there will be receptive fields, and on the second dimensions as many voxels as there are in a receptive field
-    n_receptive_fields = input_data_array[0][:, :, :, 0].size * len(input_data_array) # ie voxels per image times number of images
-    receptive_field_size = window_d_x * window_d_y * window_d_z * input_data_array[0][0,0,0,:].size
-    inputs = np.empty((n_receptive_fields, receptive_field_size))
-    output = np.empty(n_receptive_fields)
-
-    index = 0
-
-
-    # Iterate through all images
-    for i in range(0, len(input_data_array)):
-
-        input_data = input_data_array[i]
-        output_data = output_data_array[i]
-
-        if (input_data[:,:,:,0].shape != output_data.shape):
-            raise ValueError('Input and output do not have the same shape.', input_data[:,:,:,0].shape, output_data.shape)
-
-        n_x, n_y, n_z, n_c = input_data.shape
-
-        # pad the image to allow for an receptive field even at the borders
-        padding = max([rf_x, rf_y, rf_z])
-        padded_input_data = pad(input_data, padding)
-
-        input_fields = rolling_window(padded_input_data, (window_d_x, window_d_y, window_d_z, 0))
-
-        # TODO: try returning the whole flattened array?
-
-        for x, y, z in itertools.product(range(n_x),
-                                         range(n_y),
-                                         range(n_z)):
-
-            # Reshape to linear input
-            linear_input_field = np.reshape(input_fields[x, y, z], input_fields[x, y, z].size)
-            inputs[index, :] = linear_input_field
-            # inputs.append(linear_input_field)
-
-            output_voxel = np.array([output_data[x, y, z]])
-            output[index] = output_voxel
-            index += 1
-            # output.append(output_voxel)
-
-
-    # inputs = np.squeeze(inputs)
-    # output = np.squeeze(output)
-
-    print('Entire dataset. Input shape: ', inputs.shape,
-          ' and output shape: ', output.shape)
-
-    # print('IN', inputs[5000:5050])
-    # print('OUT', output[5000:5050])
-
-    return inputs, output
-
-def old_reshape_to_receptive_field(input_data_array, output_data_array, receptive_field_dimensions) :
-    # Dimensions of the receptive field defined as distance to center point in every direction
-    rf_x, rf_y, rf_z = receptive_field_dimensions
-
-    # Declare final lists going into model
-    inputs = []
-    output = []
-
-    window_d_x, window_d_y, window_d_z  = 2 * np.array(receptive_field_dimensions) + 1
-    print('Receptive field window dimensions are: ', window_d_x, window_d_y, window_d_z )
-
-    # Iterate through all images
-    for i in range(0, len(input_data_array)):
-
-        input_data = input_data_array[i]
-        output_data = output_data_array[i]
-
-        if (input_data[:,:,:,0].shape != output_data.shape):
-            raise ValueError('Input and output do not have the same shape.', input_data[:,:,:,0].shape, output_data.shape)
-
-        n_x, n_y, n_z, n_c = input_data.shape
-
-        # pad the image to allow for an receptive field even at the borders
-        padding = max([rf_x, rf_y, rf_z])
-        padded_input_data = pad(input_data, padding)
-
-        # iterate through all pixels in image and put receptive field as input for this output pixel
-        for x, y, z in itertools.product(range(n_x),
-                                         range(n_y),
-                                         range(n_z)):
-        # for x, y, z in itertools.product(range(2),
-        #                                  range(2),
-        #                                  range(2)):
-            px = x + padding; py = y + padding; pz = z + padding
-
-            output_voxel = np.array([output_data[x,y,z]])
-            output.append(output_voxel)
-
-            input_field = padded_input_data[
-                px - rf_x : px + rf_x + 1,
-                py - rf_y : py + rf_y + 1,
-                pz - rf_z : pz + rf_z + 1,
-                :
-            ]
-            linear_input = np.reshape(input_field, input_field.size)
-            inputs.append(linear_input)
-
-
-    inputs = np.array(inputs)
-    output = np.array(output)
-
-    print('Entire dataset. Input shape: ', inputs.shape,
-          ' and output shape: ', output.shape)
-
-    # print('IN', inputs[5000:5050])
-    # print('OUT', output[5000:5050])
-
-
-    return inputs, output
-
-
 def predict(input_data, model, receptive_field_dimensions):
     # Dimensions of the receptive field defined as distance to center point in every direction
     rf_x, rf_y, rf_z = receptive_field_dimensions
-    window_d_x, window_d_y, window_d_z  = 2 * np.array(receptive_field_dimensions) + 1
+    window_d_x, window_d_y, window_d_z = 2 * np.array(receptive_field_dimensions) + 1
     print('Receptive field window dimensions are: ', window_d_x, window_d_y, window_d_z )
 
     n_x, n_y, n_z, n_c = input_data.shape
     print('Predicting from input: ', input_data.shape)
+    receptive_field_size = window_d_x * window_d_y * window_d_z * n_c
+    n_voxels_per_subject = n_x * n_y * n_z
 
     output = np.zeros([n_x, n_y, n_z])
 
     # Pad input image with 0 (neutral) border to be able to get an receptive field at corner voxels
     padding = max([rf_x, rf_y, rf_z])
-    padded_input_data = pad(input_data, padding)
+    padded_input_data = np.pad(input_data, ((padding, padding), (padding, padding), (padding, padding), (0,0)), mode='constant', constant_values=0)
 
-    # input_fields = rolling_window(padded_input_data, (window_d_x, window_d_y, window_d_z, 0))
+    input_fields = rolling_window(padded_input_data, (window_d_x, window_d_y, window_d_z, 0))
 
-    # iterate through all pixels in image and put receptive field as input for this output pixel
-    for x, y, z in itertools.product(range(n_x),
-                                     range(n_y),
-                                     range(n_z)):
+    inputs = input_fields.reshape((n_voxels_per_subject, receptive_field_size))
 
-        px = x + padding; py = y + padding; pz = z + padding
-
-        input_field = padded_input_data[
-            px - rf_x : px + rf_x + 1,
-            py - rf_y : py + rf_y + 1,
-            pz - rf_z : pz + rf_z + 1,
-            :
-        ]
-
-
-        # Reshape to linear input
-        # linear_input = np.reshape(input_fields[x, y, z], input_fields[x, y, z].size)
-        linear_input = np.reshape(input_field, input_field.size)
-
-        linear_input = np.reshape(linear_input, (1, -1)) # as this is only one sample
-
-        output[x, y, z] = model.predict_proba(linear_input)[0][1]
-        # output[x, y, z] = (1 - model.predict_proba(linear_input)[0][1])
+    output = model.predict_proba(inputs)
+    output = output[:, 1].reshape(n_x, n_y, n_z)
 
     return output
-# TODO use np funciton
-def pad(image_with_channels, padding):
-    """
-    Pad input image with 0 (neutral) border to be able to get an receptive field at corner voxels
-
-    Args:
-        image_with_channels: image with n_c channels that is to be padded in its 3 dimensions
-        padding: thickness of padding
-
-    Returns:
-        padded_data
-    """
-
-    n_x, n_y, n_z, n_c = image_with_channels.shape
-    padded_image = np.zeros([n_x + 2 * padding, n_y + 2 * padding, n_z + 2 * padding, n_c])
-    for c in range(n_c):
-        channel = image_with_channels[:, :, :, c]
-        padded_channel = np.pad(channel, pad_width=padding, mode='constant', constant_values=0)
-        padded_image[:, :, :, c] = padded_channel
-
-    return padded_image

--- a/analysis/voxelWise/receptiveField.py
+++ b/analysis/voxelWise/receptiveField.py
@@ -31,7 +31,6 @@ def shorter_new_reshape_to_receptive_field(input_data_list, output_data_list, re
     n_x, n_y, n_z, n_c = input_data_list[0].shape
     n_voxels_per_subject = n_x * n_y * n_z
 
-
     # pad all images to allow for an receptive field even at the borders
     padding = max([rf_x, rf_y, rf_z])
     padded_data = [pad(x, padding) for x in input_data_list]

--- a/analysis/voxelWise/receptiveField.py
+++ b/analysis/voxelWise/receptiveField.py
@@ -7,27 +7,33 @@ import numpy as np
 import itertools
 
 def reshape_to_receptive_field(input_data_list, output_data_list, receptive_field_dimensions) :
+    temp = new_reshape_to_receptive_field(input_data_list, output_data_list, receptive_field_dimensions)
+
+    # temp = old_reshape_to_receptive_field(input_data_list, output_data_list, receptive_field_dimensions)
+
+    return temp
+
+def new_reshape_to_receptive_field(input_data_list, output_data_list, receptive_field_dimensions) :
     # Dimensions of the receptive field defined as distance to center point in every direction
     rf_x, rf_y, rf_z = receptive_field_dimensions
-
-    # Declare final lists going into model
-    # inputs = []
-    # output = []
-    #
     window_d_x, window_d_y, window_d_z  = 2 * np.array(receptive_field_dimensions) + 1
     print('Receptive field window dimensions are: ', window_d_x, window_d_y, window_d_z )
+
+    # Declare final array going into model
     # Initialize the inputs array as long as there will be receptive fields, and on the second dimensions as many voxels as there are in a receptive field
     n_receptive_fields = input_data_list[0][:, :, :, 0].size * len(input_data_list) # ie voxels per image times number of images
     receptive_field_size = window_d_x * window_d_y * window_d_z * input_data_list[0][0,0,0,:].size
     inputs = np.empty((n_receptive_fields, receptive_field_size))
     output = np.empty(n_receptive_fields)
 
+    index = 0
+
+
     # Iterate through all images
     for i in range(0, len(input_data_list)):
 
         input_data = input_data_list[i]
         output_data = output_data_list[i]
-        index = 0
 
         if (input_data[:,:,:,0].shape != output_data.shape):
             raise ValueError('Input and output do not have the same shape.', input_data[:,:,:,0].shape, output_data.shape)
@@ -54,37 +60,74 @@ def reshape_to_receptive_field(input_data_list, output_data_list, receptive_fiel
             index += 1
             # output.append(output_voxel)
 
-
-        # # iterate through all pixels in image and put receptive field as input for this output pixel
-        # for x, y, z in itertools.product(range(n_x),
-        #                                  range(n_y),
-        #                                  range(n_z)):
-        # # for x, y, z in itertools.product(range(2),
-        # #                                  range(2),
-        # #                                  range(2)):
-        #     px = x + padding; py = y + padding; pz = z + padding
-        #
-        #     output_voxel = np.array([output_data[x,y,z]])
-        #     output.append(output_voxel)
-        #
-        #     input_field = padded_input_data[
-        #         px - rf_x : px + rf_x + 1,
-        #         py - rf_y : py + rf_y + 1,
-        #         pz - rf_z : pz + rf_z + 1,
-        #         :
-        #     ]
-        #     linear_input = np.reshape(input_field, input_field.size)
-        #     inputs.append(linear_input)
-
-
-    # inputs = np.array(inputs)
-    # output = np.array(output)
-
-    inputs = np.squeeze(inputs)
-    output = np.squeeze(output)
+    # inputs = np.squeeze(inputs)
+    # output = np.squeeze(output)
 
     print('Entire dataset. Input shape: ', inputs.shape,
           ' and output shape: ', output.shape)
+
+    # print('IN', inputs[5000:5050])
+    # print('OUT', output[5000:5050])
+
+    return inputs, output
+
+def old_reshape_to_receptive_field(input_data_list, output_data_list, receptive_field_dimensions) :
+    # Dimensions of the receptive field defined as distance to center point in every direction
+    rf_x, rf_y, rf_z = receptive_field_dimensions
+
+    # Declare final lists going into model
+    inputs = []
+    output = []
+
+    window_d_x, window_d_y, window_d_z  = 2 * np.array(receptive_field_dimensions) + 1
+    print('Receptive field window dimensions are: ', window_d_x, window_d_y, window_d_z )
+
+    # Iterate through all images
+    for i in range(0, len(input_data_list)):
+
+        input_data = input_data_list[i]
+        output_data = output_data_list[i]
+
+        if (input_data[:,:,:,0].shape != output_data.shape):
+            raise ValueError('Input and output do not have the same shape.', input_data[:,:,:,0].shape, output_data.shape)
+
+        n_x, n_y, n_z, n_c = input_data.shape
+
+        # pad the image to allow for an receptive field even at the borders
+        padding = max([rf_x, rf_y, rf_z])
+        padded_input_data = pad(input_data, padding)
+
+        # iterate through all pixels in image and put receptive field as input for this output pixel
+        for x, y, z in itertools.product(range(n_x),
+                                         range(n_y),
+                                         range(n_z)):
+        # for x, y, z in itertools.product(range(2),
+        #                                  range(2),
+        #                                  range(2)):
+            px = x + padding; py = y + padding; pz = z + padding
+
+            output_voxel = np.array([output_data[x,y,z]])
+            output.append(output_voxel)
+
+            input_field = padded_input_data[
+                px - rf_x : px + rf_x + 1,
+                py - rf_y : py + rf_y + 1,
+                pz - rf_z : pz + rf_z + 1,
+                :
+            ]
+            linear_input = np.reshape(input_field, input_field.size)
+            inputs.append(linear_input)
+
+
+    inputs = np.array(inputs)
+    output = np.array(output)
+
+    print('Entire dataset. Input shape: ', inputs.shape,
+          ' and output shape: ', output.shape)
+
+    # print('IN', inputs[5000:5050])
+    # print('OUT', output[5000:5050])
+
 
     return inputs, output
 
@@ -92,6 +135,8 @@ def reshape_to_receptive_field(input_data_list, output_data_list, receptive_fiel
 def predict(input_data, model, receptive_field_dimensions):
     # Dimensions of the receptive field defined as distance to center point in every direction
     rf_x, rf_y, rf_z = receptive_field_dimensions
+    window_d_x, window_d_y, window_d_z  = 2 * np.array(receptive_field_dimensions) + 1
+    print('Receptive field window dimensions are: ', window_d_x, window_d_y, window_d_z )
 
     n_x, n_y, n_z, n_c = input_data.shape
     print('Predicting from input: ', input_data.shape)
@@ -101,6 +146,8 @@ def predict(input_data, model, receptive_field_dimensions):
     # Pad input image with 0 (neutral) border to be able to get an receptive field at corner voxels
     padding = max([rf_x, rf_y, rf_z])
     padded_input_data = pad(input_data, padding)
+
+    # input_fields = rolling_window(padded_input_data, (window_d_x, window_d_y, window_d_z, 0))
 
     # iterate through all pixels in image and put receptive field as input for this output pixel
     for x, y, z in itertools.product(range(n_x),
@@ -116,10 +163,15 @@ def predict(input_data, model, receptive_field_dimensions):
             :
         ]
 
+
+        # Reshape to linear input
+        # linear_input = np.reshape(input_fields[x, y, z], input_fields[x, y, z].size)
         linear_input = np.reshape(input_field, input_field.size)
+
         linear_input = np.reshape(linear_input, (1, -1)) # as this is only one sample
 
         output[x, y, z] = model.predict_proba(linear_input)[0][1]
+        # output[x, y, z] = (1 - model.predict_proba(linear_input)[0][1])
 
     return output
 

--- a/analysis/voxelWise/receptiveField.py
+++ b/analysis/voxelWise/receptiveField.py
@@ -16,7 +16,7 @@ def reshape_to_receptive_field(input_data_list, output_data_list, receptive_fiel
     #
     window_d_x, window_d_y, window_d_z  = 2 * np.array(receptive_field_dimensions) + 1
     print('Receptive field window dimensions are: ', window_d_x, window_d_y, window_d_z )
-    inputs = np.empty((input_data_list[0][:,:,:,0].size, window_d_x * window_d_y * window_d_z))
+    inputs = np.empty((input_data_list[0][:,:,:,0].size, window_d_x * window_d_y * window_d_z, input_data_list[0][0,0,0,:].size))
     output = np.empty(input_data_list[0][:,:,:,0].size)
 
     # Iterate through all images
@@ -43,7 +43,7 @@ def reshape_to_receptive_field(input_data_list, output_data_list, receptive_fiel
 
             # Reshape to linear input
             linear_input_field = np.reshape(input_fields[x, y, z], input_fields[x, y, z].size)
-            inputs[index,:] = linear_input_field
+            inputs[index, :, :] = linear_input_field
             # inputs.append(linear_input_field)
 
             output_voxel = np.array([output_data[x, y, z]])
@@ -76,6 +76,9 @@ def reshape_to_receptive_field(input_data_list, output_data_list, receptive_fiel
 
     # inputs = np.array(inputs)
     # output = np.array(output)
+
+    inputs = np.squeeze(inputs)
+    output = np.squeeze(output)
 
     print('Entire dataset. Input shape: ', inputs.shape,
           ' and output shape: ', output.shape)

--- a/analysis/voxelWise/receptiveField.py
+++ b/analysis/voxelWise/receptiveField.py
@@ -7,11 +7,67 @@ import numpy as np
 import itertools
 
 def reshape_to_receptive_field(input_data_list, output_data_list, receptive_field_dimensions) :
-    temp = new_reshape_to_receptive_field(input_data_list, output_data_list, receptive_field_dimensions)
+    temp = short_new_reshape_to_receptive_field(input_data_list, output_data_list, receptive_field_dimensions)
+    # a_temp2, b_temp2 = new_reshape_to_receptive_field(input_data_list, output_data_list, receptive_field_dimensions)
+
+    # print('comparing inpout, output', np.array_equal(a_temp, a_temp2), np.array_equal(b_temp, b_temp2))
+
 
     # temp = old_reshape_to_receptive_field(input_data_list, output_data_list, receptive_field_dimensions)
 
     return temp
+
+def short_new_reshape_to_receptive_field(input_data_list, output_data_list, receptive_field_dimensions) :
+    # Dimensions of the receptive field defined as distance to center point in every direction
+    rf_x, rf_y, rf_z = receptive_field_dimensions
+    window_d_x, window_d_y, window_d_z  = 2 * np.array(receptive_field_dimensions) + 1
+    print('Receptive field window dimensions are: ', window_d_x, window_d_y, window_d_z )
+
+    # Declare final array going into model
+    # Initialize the inputs array as long as there will be receptive fields, and on the second dimensions as many voxels as there are in a receptive field
+    n_receptive_fields = input_data_list[0][:, :, :, 0].size * len(input_data_list) # ie voxels per image times number of images
+    receptive_field_size = window_d_x * window_d_y * window_d_z * input_data_list[0][0,0,0,:].size
+    inputs = np.empty((n_receptive_fields, receptive_field_size))
+    outputs = np.empty(n_receptive_fields)
+
+    index = 0
+
+
+    # Iterate through all images
+    for i in range(0, len(input_data_list)):
+
+        input_data = input_data_list[i]
+        output_data = output_data_list[i]
+
+        if (input_data[:,:,:,0].shape != output_data.shape):
+            raise ValueError('Input and output do not have the same shape.', input_data[:,:,:,0].shape, output_data.shape)
+
+        n_x, n_y, n_z, n_c = input_data.shape
+        n_voxels_per_subject = n_x * n_y * n_z
+
+        # pad the image to allow for an receptive field even at the borders
+        padding = max([rf_x, rf_y, rf_z])
+        padded_input_data = pad(input_data, padding)
+
+        # Create patches centered on all the voxels in the image
+        # (do not use the 4th dimension for patches, as this is the perfusion parameter channel)
+        input_fields = rolling_window(padded_input_data, (window_d_x, window_d_y, window_d_z, 0))
+        # Reshape to linear input
+        linear_input_fields = input_fields.reshape((n_voxels_per_subject, n_c))
+        inputs[index : index + n_voxels_per_subject] = linear_input_fields
+
+        # Reshape to linear output
+        linear_output = output_data.reshape(n_voxels_per_subject)
+        outputs[index : index + n_voxels_per_subject] = linear_output
+
+        index += n_voxels_per_subject
+    # End for (loop through subjects)
+
+    print('Entire dataset. Input shape: ', inputs.shape,
+          ' and output shape: ', outputs.shape)
+
+    return inputs, outputs
+
 
 def new_reshape_to_receptive_field(input_data_list, output_data_list, receptive_field_dimensions) :
     # Dimensions of the receptive field defined as distance to center point in every direction
@@ -46,6 +102,8 @@ def new_reshape_to_receptive_field(input_data_list, output_data_list, receptive_
 
         input_fields = rolling_window(padded_input_data, (window_d_x, window_d_y, window_d_z, 0))
 
+        # TODO: try returning the whole flattened array?
+
         for x, y, z in itertools.product(range(n_x),
                                          range(n_y),
                                          range(n_z)):
@@ -59,6 +117,14 @@ def new_reshape_to_receptive_field(input_data_list, output_data_list, receptive_
             output[index] = output_voxel
             index += 1
             # output.append(output_voxel)
+
+        lin_reshape = input_fields.reshape((n_x * n_y * n_z, n_c))
+        lin_reshape_out = output_data.reshape(n_x * n_y * n_z)
+        print('ooooooooooooo', lin_reshape.shape, inputs.shape, np.array_equal(lin_reshape, inputs))
+        print('iiiiiiiii', lin_reshape_out.shape, lin_reshape_out.shape, np.array_equal(lin_reshape_out, output))
+
+
+
 
     # inputs = np.squeeze(inputs)
     # output = np.squeeze(output)


### PR DESCRIPTION
Using as_strided gives a view of the array, which is, in theory, more memory efficient. However, XGboost seems to unpack this view, there is therefore no notable difference.

Speed improvement : x50