### PR TITLE
Use channel normalisation

### DIFF
--- a/analysis/voxelWise/channel_normalisation.py
+++ b/analysis/voxelWise/channel_normalisation.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+def normalise_channel(all_input_data, masks, channel):
+    """
+    The selected channel is normalised by dividing all its data by the median value
+    in healthy tissue. Healthy tissue is defined as the tissue where Tmax < 4s.
+
+    Args:
+        all_input_data : image input data for all subjects in form of an np array [subject, x, y, z, c]
+            Data should not be scaled beforehand!
+        masks: boolean array differentiating brain from brackground [subject, x, y, z]
+        channel : 0 - Tmax, 1 - CBF, 2 - MTT, 3 - CBV
+
+    Returns: normalised_channel
+    """
+    channels =  {0:'Tmax', 1:'CBF', 2:'MTT', 3:'CBV'}
+    print('Normalising channel', channels[channel])
+    print('NO FEATURE SCALING SHOULD BE APPLIED TO TMAX BEFOREHAND')
+    channel_to_normalise = all_input_data[:,:,:,:,channel]
+    Tmax = all_input_data[:,:,:,:,0]
+    normalised_channel = np.empty(channel_to_normalise.shape)
+
+    for p in range(channel_to_normalise.shape[0]):
+        masked_healty_image_voxels = channel_to_normalise[p,:,:,:][np.all([masks[p], Tmax[p,:,:,:] < 4], axis = 0)]
+        median_channel_healthy_tissue = np.median(masked_healty_image_voxels)
+        normalised_channel[p,:,:,:] = np.divide(channel_to_normalise[p,:,:,:], median_channel_healthy_tissue)
+    return normalised_channel

--- a/analysis/voxelWise/rf_hyperopt.py
+++ b/analysis/voxelWise/rf_hyperopt.py
@@ -9,6 +9,7 @@ from vxl_NN.Keras_model import TwoLayerNetwork
 from vxl_threshold.Tmax6 import Tmax6_Model_Generator
 from vxl_threshold.customThresh import customThreshold_Model_Generator
 from wrapper_cv import launch_cv
+from channel_normalisation import normalise_channel
 
 # main_dir = '/Users/julian/master/data/from_Server'
 # main_dir = '/Users/julian/master/server_output'
@@ -19,7 +20,9 @@ main_save_dir = os.path.join(main_dir, 'temp_data')
 
 CLIN, IN, OUT, MASKS = data_loader.load_saved_data(data_dir)
 # Order: 'wcoreg_RAPID_Tmax', 'wcoreg_RAPID_rCBF', 'wcoreg_RAPID_MTT', 'wcoreg_RAPID_rCBV'
-IN = IN[:,:,:,:,0]
+
+normalised_CBF = normalise_channel(IN, MASKS, 1)
+IN = normalised_CBF
 CLIN = None
 # MASKS = numpy.full(OUT.shape, True)
 # IN, OUT = manual_data.load(data_dir)
@@ -34,7 +37,7 @@ Model_Generator = customThreshold_Model_Generator(IN.shape, feature_scaling)
 
 for rf in range(1):
     rf_dim = [rf, rf, rf]
-    model_name = 'customThresh_Tmax0_rf_' + str(rf)
+    model_name = 'customThresh_normCBF1_rf_' + str(rf)
     launch_cv(model_name, Model_Generator, rf_dim, IN, OUT, CLIN, MASKS, feature_scaling,
                     n_repeats, n_folds, main_save_dir, main_output_dir)
 


### PR DESCRIPTION
The selected channel is normalised by dividing all its data by the median value
    in healthy tissue. Healthy tissue is defined as the tissue where Tmax < 4s.
as sugessted by RAPID algo from Straka et al