### PR TITLE
Normalise by contralateral side

### DIFF
--- a/analysis/sampling_utils.py
+++ b/analysis/sampling_utils.py
@@ -87,3 +87,21 @@ def balance(X, y, verbose = False):
         print('Remaining data points after balancing: ', sorted(Counter(y_resampled).items()))
 
     return (X_resampled, y_resampled)
+
+def get_controlateral_side_mask(self, all_data, VOI):
+    '''
+    Get mask of the controlateral side of the space
+    :param all_data: all image data with shape [x, y, z, c]
+    :param VOIs: coordinates of region of which the contralateral side is defined [x, y, z]
+    :return: controlateral_side_mask, mask marking contralateral side of VOI in image as True
+    '''
+    x_center = all_data.shape[0] // 2
+    controlateral_side_mask = np.full(all_data.shape[:4], False)
+    # VOI is on the right
+    if VOI[0] > x_center:
+        # return left side
+        controlateral_side_mask[:x_center, :, :] = True
+    else: # VOI is on the left
+        # return right side
+        controlateral_side_mask[x_center:, :, :] = True
+    return controlateral_side_mask

--- a/analysis/voxelWise/main.py
+++ b/analysis/voxelWise/main.py
@@ -1,26 +1,24 @@
-import os, sys, numpy
+import os, sys, random, string
 sys.path.insert(0, '../')
 import data_loader, manual_data
-from vxl_xgboost.default_ram_xgb import Default_ram_xgb
-from vxl_xgboost.ram_xgb import Ram_xgb
-from vxl_glm.LogReg_glm import LogReg_glm
-from vxl_NN.LogReg_NN import LogReg_NN
-from vxl_NN.Keras_model import TwoLayerNetwork
-from vxl_threshold.Tmax6 import Tmax6_Model_Generator
+# from vxl_xgboost.default_ram_xgb import Default_ram_xgb
+# from vxl_xgboost.ram_xgb import Ram_xgb
+# from vxl_glm.LogReg_glm import LogReg_glm
+# from vxl_NN.LogReg_NN import LogReg_NN
+# from vxl_NN.Keras_model import TwoLayerNetwork
+# from vxl_threshold.Tmax6 import Tmax6_Model_Generator
 from vxl_threshold.RAPID_model import RAPID_Model_Generator
 from wrapper_cv import launch_cv, rf_hyperopt
 from channel_normalisation import multi_subj_channel_normalisation
 
-# main_dir = '/Users/julian/master/data/from_Server/'
+# main_dir = '/Users/julian/master/data/all2016_subset'
 main_dir = '/home/klug/data/working_data/'
-data_dir = os.path.join(main_dir, 'saved_data')
+data_dir = os.path.join(main_dir, '')
 main_output_dir = os.path.join(main_dir, 'models')
 main_save_dir = os.path.join(main_dir, 'temp_data')
 
 CLIN, IN, OUT, MASKS, IDS, PARAMS = data_loader.load_saved_data(data_dir)
 # Order: 'wcoreg_RAPID_Tmax', 'wcoreg_RAPID_rCBF', 'wcoreg_RAPID_MTT', 'wcoreg_RAPID_rCBV'
-
-print(PARAMS)
 
 # Ignore clinical data for now
 CLIN = None
@@ -39,7 +37,7 @@ feature_scaling = False
 
 Model_Generator = RAPID_Model_Generator(IN.shape, feature_scaling)
 
-model_name = 'RAPID_CBV30_ofNormalised_inPenumbra'
+model_name = 'RAPID_CBV30_ofDuallyNormalised_inPenumbra'
 rf_hp_start = 0
 rf_hp_end = 1
 rf_hyperopt(model_name, Model_Generator, IN, OUT, CLIN, MASKS, IDS, feature_scaling,

--- a/analysis/voxelWise/vxl_threshold/RAPID_model.py
+++ b/analysis/voxelWise/vxl_threshold/RAPID_model.py
@@ -13,7 +13,18 @@ class RAPID_threshold():
         if self.rf != 0:
             raise ValueError('Model only valid for Rf = 0.')
 
-    def normalise_channel(self, all_channel_data, mask, channel):
+    def reconstruct_image(self, data_points, data_positions, n_channels):
+        '''
+        Reconstruct 2D/3D shape of images with available data filled in (may not be whole image because of sampling)
+        :param data_points: data for every available voxel [i, c]
+        :param data_positions: (n, x, y, z) boolean array where True marks a given data_point
+        :return: reconstructed
+        '''
+        reconstructed = np.zeros(data_positions.shape + tuple([n_channels]))
+        reconstructed[data_positions == 1] = data_points
+        return reconstructed
+
+    def normalise_channel_by_Tmax4(self, all_channel_data, data_positions, channel):
         """
         The selected channel is normalised by dividing all its data by the median value
         in healthy tissue. Healthy tissue is defined as the tissue where Tmax < 4s.
@@ -21,20 +32,69 @@ class RAPID_threshold():
         Args:
             all_channel_data : image input data for all subjects in form of an np array [..., c]
                 Data should not be scaled beforehand!
-            mask: boolean array differentiating brain from brackground [...]
+            data_positions: boolean map in original space with 1 as placeholder for data points
+            mask: boolean array differentiating brain from background [...]
             channel to normalise: 0 - Tmax, 1 - CBF, 2 - MTT, 3 - CBV
 
         Returns: normalised_channel
         """
-        channel_to_normalise = all_channel_data[... ,channel]
-        Tmax = all_channel_data[..., 0]
-        normalised_channel = np.empty(channel_to_normalise.shape)
+        # reconstruct to be able to separate individual subjects
+        reconstructed = self.reconstruct_image(all_channel_data, data_positions, all_channel_data.shape[-1])
+        channel_to_normalise = reconstructed[..., channel]
+        Tmax = reconstructed[..., 0]
+        normalised_channel = np.zeros(channel_to_normalise.shape)
+        for subj in range(data_positions.shape[0]):
+            masked_healthy_image_voxels = channel_to_normalise[subj][np.all([data_positions[subj] == 1, Tmax[subj] < 4], axis=0)]
+            # clip to remove extremes that falsify results
+            masked_healthy_image_voxels = np.clip(masked_healthy_image_voxels, np.percentile(masked_healthy_image_voxels, 1), np.percentile(masked_healthy_image_voxels, 99))
+            median_channel_healthy_tissue = np.median(masked_healthy_image_voxels)
+            normalised_channel[subj] = np.divide(channel_to_normalise[subj], median_channel_healthy_tissue)
 
-        masked_healthy_image_voxels = channel_to_normalise[np.all([mask, Tmax < 4], axis = 0)]
-        median_channel_healthy_tissue = np.median(masked_healthy_image_voxels)
-        normalised_channel = np.divide(channel_to_normalise, median_channel_healthy_tissue)
+        image_normalised_channel = normalised_channel
+        flat_normalised_channel = normalised_channel[data_positions == 1].reshape(-1)
+        return image_normalised_channel, flat_normalised_channel
 
-        return normalised_channel
+    def normalise_channel_by_contralateral(self, all_channel_data, data_positions, channel):
+        '''
+        Normalise a channel by dividing every voxel by the median value of contralateral side
+        :param all_channel_data: image input data for all subjects in form of an np array [i, c]
+        :param data_positions: boolean map in original space with 1 as placeholder for data points
+        :param channel: channel to normalise: 0 - Tmax, 1 - CBF, 2 - MTT, 3 - CBV
+        :return: (image_normalised_channel, flat_normalised_channel) - normalised channel in 3D and flat form
+        '''
+        # Recover 3D shape of data
+        reconstructed_data = self.reconstruct_image(all_channel_data, data_positions, all_channel_data.shape[-1])
+        channel_to_normalise_data = reconstructed_data[... ,channel]
+        normalised_channel = np.zeros(channel_to_normalise_data.shape, dtype=np.float64)
+        x_center = channel_to_normalise_data.shape[1] // 2
+
+        for subj in range(channel_to_normalise_data.shape[0]):
+            # normalise left side
+            right_side = channel_to_normalise_data[subj][x_center:][data_positions[subj][x_center:] == 1]
+            clipped_right_side = np.clip(right_side, np.percentile(right_side, 1), np.percentile(right_side, 99))
+            right_side_median = np.nanmedian(clipped_right_side)
+            normalised_channel[subj][:x_center] = np.divide(channel_to_normalise_data[subj][:x_center], right_side_median)
+
+            # normalise right side
+            left_side = channel_to_normalise_data[subj][:x_center][data_positions[subj][:x_center] == 1]
+            clipped_left_side = np.clip(left_side, np.percentile(left_side, 1), np.percentile(left_side, 99))
+            left_side_median = np.nanmedian(clipped_left_side)
+            normalised_channel[subj][x_center:] = np.divide(channel_to_normalise_data[subj][x_center:], left_side_median)
+
+        image_normalised_channel = normalised_channel
+        flat_normalised_channel = normalised_channel[data_positions == 1].reshape(-1)
+        return image_normalised_channel, flat_normalised_channel
+
+    def normalise_channel(self, all_channel_data, data_positions, channel):
+        '''
+        :param all_channel_data: image input data for all subjects in form of an np array [i, c]
+        :param data_positions: boolean map in original space with 1 as placeholder for data points
+        :param channel: channel to normalise: 0 - Tmax, 1 - CBF, 2 - MTT, 3 - CBV
+        :return: normalised channel by Tmax and by contralateral side
+        '''
+        normalised_by_Tmax4 = self.normalise_channel_by_Tmax4(all_channel_data, data_positions, channel)
+        normalised_by_contralateral = self.normalise_channel_by_contralateral(all_channel_data, data_positions, channel)
+        return normalised_by_Tmax4[1], normalised_by_contralateral[1]
 
     def threshold_Tmax6(self, data):
         # Get penumbra mask
@@ -44,26 +104,30 @@ class RAPID_threshold():
         tresholded_voxels[Tmax > 6] = 1
         return np.squeeze(tresholded_voxels)
 
-    def fit(self, X_train, y_train):
+    def fit(self, X_train, y_train, train_batch_positions):
         Tmax = X_train[..., 0]
-        normalised_CBF = self.normalise_channel(X_train, np.ones(Tmax.shape), 1)
-        penumbra_indeces = np.where(Tmax > 6) # define penumbra
-        penumbra_normalised_CBF = normalised_CBF[penumbra_indeces]
-        fpr, tpr, thresholds = roc_curve(y_train[penumbra_indeces], penumbra_normalised_CBF)
+        CBF_normalised_byTmax4, CBF_normalised_byContralateral = self.normalise_channel(X_train, train_batch_positions, 1)
+        penumbra_indices = np.where(Tmax > 6) # define penumbra
+
+        # todo This training is just for show
+        penumbra_normalised_CBF = CBF_normalised_byTmax4[penumbra_indices]
+        fpr, tpr, thresholds = roc_curve(y_train[penumbra_indices], penumbra_normalised_CBF)
         # get optimal cutOff
         self.train_threshold = cutoff_youdens_j(fpr, tpr, thresholds)
         print('Training threshold:', self.train_threshold)
 
         return self
 
-    def predict_proba(self, data):
+    def predict_proba(self, data, data_position_indices):
         Tmax = data[..., 0]
-        normalised_CBF = self.normalise_channel(data, np.ones(Tmax.shape), 1)
+        CBF_normalised_byTmax4, CBF_normalised_byContralateral = self.normalise_channel(data, data_position_indices, 1)
 
-        threshold = self.fixed_threshold
+        threshold: float = self.fixed_threshold
         tresholded_voxels = np.zeros(Tmax.shape)
-        # Parts of penumbra (Tmax > 6) where CBF < 30% of healthy tissue)
-        tresholded_voxels[(normalised_CBF < threshold) & (Tmax > 6)] = 1
+        # Parts of penumbra (Tmax > 6) where CBF < 30% of healthy tissue (controlateral or region where Tmax < 4s)
+        tresholded_voxels[(CBF_normalised_byContralateral < threshold) & (Tmax > 6)] = 1
+        tresholded_voxels[(CBF_normalised_byTmax4 < threshold) & (Tmax > 6)] = 1
+
         return np.squeeze(tresholded_voxels)
 
 def RAPID_Model_Generator(X_shape, feature_scaling):

--- a/analysis/voxelWise/vxl_threshold/Threshold_Model.py
+++ b/analysis/voxelWise/vxl_threshold/Threshold_Model.py
@@ -13,10 +13,10 @@ class Threshold_Model():
 
         self.X_train = None
         self.y_train = None
-        self.train_index = 0
+        self.train_voxel_index = 0
         self.X_test = None
         self.y_test = None
-        self.test_index = 0
+        self.test_voxel_index = 0
 
         self.fold_dir = fold_dir
         self.fold_name = fold_name
@@ -29,51 +29,73 @@ class Threshold_Model():
     def get_settings():
         return {}
 
-    def initialise_train_data(self, n_datapoints, data_dimensions):
-        self.X_train = np.empty([np.sum(n_datapoints), data_dimensions])
+    def initialise_train_data(self, n_datapoints, data_point_dimensions, n_images, image_spatial_dimensions):
+        '''
+        :param n_datapoints: number of individual training sample units
+        :param data_point_dimensions: number of features of each sample
+        :param n_images: number of whole images in train dataset
+        :param image_spatial_dimensions: (x, y, z) of a whole image
+        '''
+        self.X_train = np.empty([np.sum(n_datapoints), data_point_dimensions])
         self.y_train = np.empty(np.sum(n_datapoints))
-        self.train_index = 0
+        # position indices keep track of where the data was stored spatially
+        self.position_indices_train = np.zeros(((n_images,) + image_spatial_dimensions))
+        self.train_voxel_index = 0; self.train_image_index = 0
 
-    def add_train_data(self, batch_X_train, batch_y_train):
+    def add_train_data(self, batch_X_train, batch_y_train, batch_positional_indices, batch_n_images):
         """
         Add a batch of training data to the whole training data pool
 
         Args:
             batch_X_train: batch of training data
             batch_y_train: batch of training labels
+            batch_positional_indices: indices that the training data had in the whole entity (ie. image)
+            batch_n_images: number of images in this batch
         """
-        self.X_train[self.train_index : self.train_index + batch_X_train.shape[0], :] = batch_X_train
-        self.y_train[self.train_index : self.train_index + batch_y_train.shape[0]] = batch_y_train
-        self.train_index += batch_X_train.shape[0]
+        self.X_train[self.train_voxel_index : self.train_voxel_index + batch_X_train.shape[0], :] = batch_X_train
+        self.y_train[self.train_voxel_index : self.train_voxel_index + batch_y_train.shape[0]] = batch_y_train
+        self.position_indices_train[self.train_image_index : self.train_image_index + batch_n_images] \
+            = batch_positional_indices.reshape((batch_n_images,) + self.position_indices_train[0].shape)
+        self.train_voxel_index += batch_X_train.shape[0]; self.train_image_index += batch_n_images
 
-    def initialise_test_data(self, n_datapoints, data_dimensions):
-        self.X_test = np.empty([np.sum(n_datapoints), data_dimensions])
+    def initialise_test_data(self, n_datapoints, data_point_dimensions, n_images, image_spatial_dimensions):
+        '''
+        :param n_datapoints: number of individual testing sample units
+        :param data_point_dimensions: features of each sample
+        :param n_images: number of whole images in test dataset
+        :param image_spatial_dimensions: (x, y, z) of a whole image
+        '''
+        self.X_test = np.empty([np.sum(n_datapoints), data_point_dimensions])
         self.y_test = np.empty(np.sum(n_datapoints))
-        self.test_index = 0
+        # position indices keep track of where the data was stored spatially
+        self.position_indices_test = np.zeros(((n_images,) + image_spatial_dimensions))
+        self.test_voxel_index = 0; self.test_image_index = 0
 
-    def add_test_data(self, batch_X_test, batch_y_test):
+    def add_test_data(self, batch_X_test, batch_y_test, batch_positional_indices, batch_n_images):
         """
         Add a batch of testing data to the whole testing data pool
-        All testing data is saved in a svmlight file
         """
-        self.X_test[self.test_index : self.test_index + batch_X_test.shape[0], :] = batch_X_test
-        self.y_test[self.test_index : self.test_index + batch_y_test.shape[0]] = batch_y_test
-        self.test_index += batch_X_test.shape[0]
+        self.X_test[self.test_voxel_index : self.test_voxel_index + batch_X_test.shape[0], :] = batch_X_test
+        self.y_test[self.test_voxel_index : self.test_voxel_index + batch_y_test.shape[0]] = batch_y_test
+        self.position_indices_test[self.test_image_index : self.test_image_index + batch_n_images] \
+            = batch_positional_indices.reshape((batch_n_images,) + self.position_indices_test[0].shape)
+        self.test_voxel_index += batch_X_test.shape[0]; self.test_image_index += batch_n_images
+
 
     def train(self):
-        self.trained_model = self.model.fit(self.X_train, self.y_train)
+        self.trained_model = self.model.fit(self.X_train, self.y_train, self.position_indices_train)
         return self.trained_model, []
 
-    def predict(self, data):
+    def predict(self, data, data_position_indices):
         model = self.trained_model
         if not self.trained_model:
             print('Model has not been trained. Prediction may be hazardous')
             model = self.model
-        probas_ = model.predict_proba(data)
+        probas_ = model.predict_proba(data, data_position_indices)
         return probas_
 
     def predict_test_data(self):
-        probas_ = self.predict(self.X_test)
+        probas_ = self.predict(self.X_test, self.position_indices_test)
         return probas_
 
     def get_test_labels(self):

--- a/analysis/voxelWise/wrapper_cv.py
+++ b/analysis/voxelWise/wrapper_cv.py
@@ -108,7 +108,7 @@ def launch_cv(model_name, Model_Generator, rf_dim, IN, OUT, CLIN, MASKS, IDS, fe
         title = model_name + ' errored upon rf_hyperopt'
         tb = traceback.format_exc()
         body = 'RF ' + str(rf_dim) + '\n' + 'Error ' + str(e) + '\n' + str(tb)
-        notification_system.send_message(title, body)
+        if notification_system: notification_system.send_message(title, body)
         raise
 
 def rf_hyperopt(model_name, Model_Generator, IN, OUT, CLIN, MASKS, IDS, feature_scaling,


### PR DESCRIPTION
goal: have a 100% ref of contralateral side for 30% CBF thresholding

- built contralateral side normalisation
- built image reconstruction (use datapoints available in an image and their positions to rebuild the 3D shape) - this is necessary as after masking and smapling not all image is available
- rewrote Tmax4 normalisation to apply median per subject

resolves #70 