### PR TITLE
Used threshold derived from training data for evaluation

### DIFF
--- a/analysis/voxelWise/cv_framework.py
+++ b/analysis/voxelWise/cv_framework.py
@@ -88,7 +88,7 @@ def repeated_kfold_cv(Model_Generator, save_dir, save_function,
         'test_jaccard': [],
         'test_TPR': [],
         'test_FPR': [],
-        'test_thresholds': [],
+        'test_roc_thresholds': [],
         'test_positive_predictive_value': [],
         'test_thresholded_volume_deltas': [],
         'test_unthresholded_volume_deltas': [],
@@ -98,6 +98,7 @@ def repeated_kfold_cv(Model_Generator, save_dir, save_function,
         'test_image_wise_modified_hausdorff': [],
         'test_image_wise_dice': [],
         'evaluation_thresholds': [],
+        'optimal_thresholds_on_test_data': [],
         'test_penumbra_metrics': {
             'predicted_in_penumbra_ratio': []
         }
@@ -185,7 +186,7 @@ def repeated_kfold_cv(Model_Generator, save_dir, save_function,
                 results['test_roc_auc'].append(fold_result['roc_auc'])
                 results['test_TPR'].append(fold_result['tpr'])
                 results['test_FPR'].append(fold_result['fpr'])
-                results['test_thresholds'].append(fold_result['thresholds'])
+                results['test_roc_thresholds'].append(fold_result['roc_thresholds'])
                 results['test_jaccard'].append(fold_result['jaccard'])
                 results['test_positive_predictive_value'].append(fold_result['positive_predictive_value'])
                 results['test_thresholded_volume_deltas'].append(fold_result['thresholded_volume_deltas'])
@@ -200,6 +201,7 @@ def repeated_kfold_cv(Model_Generator, save_dir, save_function,
                     results['test_penumbra_metrics']['predicted_in_penumbra_ratio']\
                         .append(fold_result['penumbra_metrics']['predicted_in_penumbra_ratio'])
                 results['evaluation_thresholds'].append(fold_result['evaluation_threshold'])
+                results['optimal_thresholds_on_test_data'].append(fold_result['optimal_threshold_on_test_data'])
                 trained_models.append(fold_result['trained_model'])
                 figures.append(fold_result['figure'])
                 pass
@@ -334,8 +336,8 @@ def evaluate_fold(model, n_test_subjects, n_x, n_y, n_z, imgX, mask_array, id_ar
     Returns: result dictionary
     """
 
-    trained_model, evals_result = model.train()
-    print('Model sucessfully trained.')
+    trained_model, model_threshold, evals_result = model.train()
+    print('Model successfully trained. Threshold at:', str(model_threshold))
     probas_ = model.predict_test_data()
     y_test = model.get_test_labels()
     mask_test = mask_array[test]
@@ -343,8 +345,8 @@ def evaluate_fold(model, n_test_subjects, n_x, n_y, n_z, imgX, mask_array, id_ar
     if id_array is not None: ids_test = id_array[test]
     else: ids_test = None
 
-    results = evaluate(probas_, y_test, mask_test, ids_test, n_test_subjects, n_x, n_y, n_z)
-    print('Model sucessfully tested.')
+    results = evaluate(probas_, y_test, mask_test, ids_test, n_test_subjects, n_x, n_y, n_z, model_threshold)
+    print('Model successfully tested.')
     results['trained_model'] = trained_model
     results['train_evals'] = evals_result
 

--- a/analysis/voxelWise/vxl_glm/Glm.py
+++ b/analysis/voxelWise/vxl_glm/Glm.py
@@ -1,5 +1,7 @@
-import os
+import sys
+sys.path.insert(0, '../')
 import numpy as np
+
 
 class Glm():
     """
@@ -60,8 +62,19 @@ class Glm():
         self.test_index += batch_X_test.shape[0]
 
     def train(self):
+        """
+        Train the model on the training data that is available
+        :return: trained_model
+        :return: trained_threshold - threshold to use on predicted probabilities
+        :return: evals - array of train evaluation metrics
+        """
         self.trained_model = self.model.fit(self.X_train, self.y_train)
-        return self.trained_model, []
+
+        # default threshold for logistic regression is 0.5, determining it through analysis of test data exacerbates overfitting
+        # https://stackoverflow.com/questions/31417487/sklearn-logisticregression-and-changing-the-default-threshold-for-classification?rq=1
+        self.trained_threshold = 0.5
+
+        return self.trained_model, self.trained_threshold, []
 
     def predict(self, data, data_position_indices = None):
         probas_ = self.trained_model.predict_proba(data)

--- a/analysis/voxelWise/vxl_glm/Glm.py
+++ b/analysis/voxelWise/vxl_glm/Glm.py
@@ -1,5 +1,3 @@
-import sys
-sys.path.insert(0, '../')
 import numpy as np
 
 

--- a/analysis/voxelWise/vxl_threshold/Threshold_Model.py
+++ b/analysis/voxelWise/vxl_threshold/Threshold_Model.py
@@ -83,8 +83,15 @@ class Threshold_Model():
 
 
     def train(self):
+        """
+        Train the model on the training data that is available
+        :return: trained_model
+        :return: trained_threshold - threshold to use on predicted probabilities
+        :return: evals - array of train evaluation metrics
+        """
         self.trained_model = self.model.fit(self.X_train, self.y_train, self.position_indices_train)
-        return self.trained_model, []
+        self.trained_threshold = self.model.train_threshold
+        return self.trained_model, self.trained_threshold, []
 
     def predict(self, data, data_position_indices):
         model = self.trained_model

--- a/analysis/voxelWise/vxl_threshold/Tmax6.py
+++ b/analysis/voxelWise/vxl_threshold/Tmax6.py
@@ -14,6 +14,7 @@ class Tmax6_treshold():
             tresholded_voxels = np.zeros(X_train.shape)
             tresholded_voxels[X_train > self.threshold] = 1
             self.combinator.fit(tresholded_voxels, y_train)
+            self.train_threshold = self.threshold
         return self
 
 


### PR DESCRIPTION
why? threshold derived from testing data by youden's J on roc curve, introduces a biais into the evaluation
although this biais is the same for all evaluated models, it still gives a overly optimistic scores for binary metrics such as dice

the threshold is now derived either from the model definition, or from a roc curve analysis on the training data

resolves #88